### PR TITLE
Adds font size option and minor format improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Then adapt the example as you see fit.
 The sample [template.qmd](template.qmd) demonstrates all available tuning knobs.
 Many options are directly lifted from the `scrlttr2` class.
 
+### Setting the Font Size
+
+The default font size is 12pt. To specify a different size for the document, use the YAML option 'fontsize'
+
+```yaml
+---
+fontsize: 11pt
+---
+```
+
+Any TeX-compatible unit should work, like e.g. `ex`, `in` or `mm`. However, to avoid layout breaks, it is recommended to use one of the most common sizes `10pt`, `11pt` or `12pt`.
+
 ### Customize Fonts
 
 You can adjust fonts by adjusting Quarto's [PDF font

--- a/_extensions/brief/partials/before-body.tex
+++ b/_extensions/brief/partials/before-body.tex
@@ -57,6 +57,10 @@ $if(signature)$
 }
 $endif$
 
+$if(fontsize)$
+\KOMAoptions{fontsize=$fontsize$}
+$endif$
+
 \begin{letter}{
   $for(address)$%
     $address$$sep$\\

--- a/_extensions/brief/partials/before-body.tex
+++ b/_extensions/brief/partials/before-body.tex
@@ -61,6 +61,10 @@ $if(fontsize)$
 \KOMAoptions{fontsize=$fontsize$}
 $endif$
 
+\makeatletter
+\renewcommand*{\raggedsignature}{\raggedright}
+\makeatother
+
 \begin{letter}{
   $for(address)$%
     $address$$sep$\\


### PR DESCRIPTION
## Font Size
This PR adds the option to set the font size via the YAML.
This is achieved via the respective KOMAoption, which in turn automatically adjusts the text area on the page.
In the README this setting is explained with the possible options.

## Closing Indentation
Another small addition to the before-header.tex removes the indent from the 'closing':

**Before**:
![before](https://github.com/mavam/quarto-brief/assets/76264370/e80d378e-a661-49c3-8c99-784cc455fdf2)

**After**:
![after](https://github.com/mavam/quarto-brief/assets/76264370/91127aca-30e6-4a50-9c3b-6ae47a30ec9e)

