### PR TITLE
Fix bug related to signature insertion

### DIFF
--- a/_extensions/brief/partials/before-body.tex
+++ b/_extensions/brief/partials/before-body.tex
@@ -51,8 +51,7 @@ $endif$
 
 $if(signature)$
 \setkomavar{signature}{
-%  \includegraphics[scale=0.25]{signature}\\
-  %\bigskip\\
+ \includegraphics[width=0.2\textwidth]{$signature$}\\
   \usekomavar{fromname}
 }
 $endif$


### PR DESCRIPTION
Removed `\bigskip` so that the compilation can be continued when `signature` is set.