### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/brief/_schema.yml
+++ b/_extensions/brief/_schema.yml
@@ -1,0 +1,55 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  brief-pdf:
+    subject:
+      type: string
+      description: Subject line shown before the letter body.
+    opening:
+      type: string
+      description: Greeting line before the main letter content.
+    closing:
+      type: string
+      description: Complimentary close before the signature block.
+    signature:
+      type: string
+      description: Path to a signature image shown above sender name.
+      completion:
+        type: file
+        extensions: [.png, .jpg, .jpeg, .svg]
+    address:
+      type: array
+      description: Recipient address lines.
+      items:
+        type: string
+    date:
+      type: string
+      description: Explicit letter date value.
+    date_label:
+      type: string
+      description: Label caption used for the date field.
+    place:
+      type: string
+      description: Location shown in the heading block.
+    place_label:
+      type: string
+      description: Label caption used for the location field.
+    yourref:
+      type: string
+      description: Recipient reference value.
+    myref:
+      type: string
+      description: Sender reference value.
+    fontsize:
+      type: string
+      description: Base document font size such as 10pt, 11pt, or 12pt.
+    cc:
+      type: array
+      description: Carbon copy recipients listed at letter end.
+      items:
+        type: string
+    encl:
+      type: array
+      description: Enclosure labels listed at letter end.
+      items:
+        type: string

--- a/_extensions/brief/_snippets.json
+++ b/_extensions/brief/_snippets.json
@@ -1,0 +1,23 @@
+{
+  "Brief format setup": {
+    "prefix": "format",
+    "body": [
+      "format:",
+      "  brief-pdf: default"
+    ],
+    "description": "Enable the Brief PDF format for a document."
+  },
+  "Brief letter metadata": {
+    "prefix": "letter",
+    "body": [
+      "subject: ${1:Project update}",
+      "opening: ${2:Dear team,}",
+      "closing: ${3:Kind regards,}",
+      "address:",
+      "  - ${4:Recipient Name}",
+      "  - ${5:Street 1}",
+      "  - ${6:City}"
+    ],
+    "description": "Insert common letter metadata fields used by Brief."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/brief/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/brief/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
